### PR TITLE
Fix: Fix Go README instruction to run the app

### DIFF
--- a/be/go/README.md
+++ b/be/go/README.md
@@ -9,5 +9,5 @@ likely have significantly faster compilation times).  Just build & run with the 
 
 ```bash
 docker build . --tag captrivia-be
-docker run -it --publish "8080:8080" --mount "type=bind,source=${PWD},target=app" captrivia-be
+docker run -it --publish "8080:8080" --mount "type=bind,source=${PWD},target=/app" captrivia-be
 ```


### PR DESCRIPTION
## Description
Following the Go README's instructions to run the project, here's what happens:

```bash
# Command
docker run -it --publish "8080:8080" --mount "type=bind,source=${PWD},target=app" captrivia-be
# Output
docker: Error response from daemon: invalid mount config for type "bind": invalid mount path: 'app' mount path must be absolute.
```

## Bugfix explanation
The issue was that the target path app was not an absolute path. In Docker, when using bind mounts, the target path must be absolute. I've changed `target=app` to `target=/app`, which specifies an absolute path in the container.

This modification resolve the "invalid mount path" error. The command will now bind the current working directory (${PWD}) to the /app directory in the container.

## Steps to test
- Pull this branch
- Run the commands indicated in `be/go/README.md`

**Expected:** Server should be running 

---

Let me know if you have any questions or feedback,
JB